### PR TITLE
Allow simplito/elliptic-php upgrades

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   },
   "require": {
     "php": "^7.1.3|^8.0",
-    "simplito/elliptic-php": "1.0.6"
+    "simplito/elliptic-php": "^1.0.6"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,


### PR DESCRIPTION
Upgrades to this library are safe for PHP 8/8.1 (and I think this is also true for the outdated PHP 7).